### PR TITLE
Fixes #35: Add ability to pass location to SYNTAX.parse() methods 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,8 +27,8 @@ val settings = Common.settings ++ Common.publish ++ Seq(
   credentials ++= Common.credentials(),
   libraryDependencies ++= Seq(
     "org.scalatest"     %%% "scalatest"       % "3.0.5" % "test",
-    "com.github.amlorg" %%% "amf-webapi"      % "3.4.0",
-    "com.github.amlorg" %%% "amf-validation"  % "3.4.0"
+    "com.github.amlorg" %%% "amf-webapi"      % "3.5.0",
+    "com.github.amlorg" %%% "amf-validation"  % "3.5.0"
   )
 )
 

--- a/examples/api-specs/includes/cat-schema.json
+++ b/examples/api-specs/includes/cat-schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://example.com/cat.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Cat",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The cat's name."
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/examples/api-specs/includes/cat-schema.yaml
+++ b/examples/api-specs/includes/cat-schema.yaml
@@ -1,0 +1,12 @@
+"$id": https://example.com/cat.schema.json
+"$schema": http://json-schema.org/draft-04/schema#
+title: Cat
+type: object
+properties:
+  name:
+    type: string
+    description: The cat's name.
+  age:
+    description: Age in years which must be equal to or greater than zero.
+    type: integer
+    minimum: 0

--- a/examples/java/src/main/java/co/acme/demo/WebApiParserDemo.java
+++ b/examples/java/src/main/java/co/acme/demo/WebApiParserDemo.java
@@ -24,6 +24,7 @@ import java.io.UnsupportedEncodingException;
 // Runs all the example classes
 public class WebApiParserDemo {
   public static void main(String[] args) throws ExecutionException, InterruptedException, UnsupportedEncodingException {
+    Raml10Parsing.parseStringWithLocation();
     Raml10Parsing.parseString();
     Raml10Parsing.parseFile();
 

--- a/examples/java/src/main/java/co/acme/parse/Raml10Parsing.java
+++ b/examples/java/src/main/java/co/acme/parse/Raml10Parsing.java
@@ -18,7 +18,7 @@ public class Raml10Parsing {
     System.out.println("Parsed Raml10 file. Expected unit encoding webapi: " + ((WebApiDocument) result).encodes());
   }
 
-  // Example of parsing RAML 1.0 file
+  // Example of parsing RAML 1.0 string
   public static void parseString() throws InterruptedException, ExecutionException {
     String inp ="#%RAML 1.0\n" +
                 "\n" +
@@ -37,6 +37,30 @@ public class Raml10Parsing {
 
     // Set API description
     api.withDescription("Very nice api");
+
+    // Generate RAML 1.0 string from updated model and log it
+    String output = Raml10.generateString(doc).get();
+    System.out.println("Generated Raml10 string:\n" + output);
+  }
+
+  // Example of parsing RAML 1.0 string with location param
+  public static void parseStringWithLocation() throws InterruptedException, ExecutionException {
+    String inp = "#%RAML 1.0\n" +
+                 "title: API with Types\n" +
+                 "/users/{id}:\n" +
+                 "  get:\n" +
+                 "    responses:\n" +
+                 "      200:\n" +
+                 "        body:\n" +
+                 "          application/json:\n" +
+                 "            type: !include cat-schema.json";
+    String location = "file://../api-specs/includes/api.raml";
+    System.out.println("Input Raml10 string:\n" + inp);
+
+    // Parse the string
+    WebApiDocument doc = (WebApiDocument) Raml10.parse(inp, location).get();
+
+    System.out.println("Parsed content location:\n" + doc.location());
 
     // Generate RAML 1.0 string from updated model and log it
     String output = Raml10.generateString(doc).get();

--- a/examples/java/src/main/java/co/acme/parse/Raml10Parsing.java
+++ b/examples/java/src/main/java/co/acme/parse/Raml10Parsing.java
@@ -54,11 +54,11 @@ public class Raml10Parsing {
                  "        body:\n" +
                  "          application/json:\n" +
                  "            type: !include cat-schema.json";
-    String location = "file://../api-specs/includes/api.raml";
+    String baseUrl = "file://../api-specs/includes/";
     System.out.println("Input Raml10 string:\n" + inp);
 
     // Parse the string
-    WebApiDocument doc = (WebApiDocument) Raml10.parse(inp, location).get();
+    WebApiDocument doc = (WebApiDocument) Raml10.parse(inp, baseUrl).get();
 
     System.out.println("Parsed content location:\n" + doc.location());
 

--- a/examples/js/raml10-string-location.js
+++ b/examples/js/raml10-string-location.js
@@ -1,0 +1,35 @@
+/**
+ * Example of parsing RAML 1.0 with basePath parameter.
+ */
+const wap = require('webapi-parser').WebApiParser
+const path = require('path')
+
+const ramlStr = `
+  #%RAML 1.0
+  title: API with Types
+  /users/{id}:
+    get:
+      responses:
+        200:
+          body:
+            application/json:
+              type: !include cat-schema.json
+`
+
+async function main () {
+  // Parse RAML 1.0 string with basePath parameter
+  console.log('Input:\n', ramlStr)
+  const fpath = path.resolve(
+    __dirname,
+    '../api-specs/includes/api.raml')
+  const location = `file://${fpath}`
+  const model = await wap.raml10.parse(ramlStr, location)
+  console.log('Model location:\n', model.location)
+  const resolved = await wap.raml10.resolve(model)
+
+  // Generate RAML 1.0 string
+  const generated = await wap.raml10.generateString(resolved)
+  console.log('Generated:\n', generated)
+}
+
+main()

--- a/examples/js/raml10-string-location.js
+++ b/examples/js/raml10-string-location.js
@@ -21,9 +21,9 @@ async function main () {
   console.log('Input:\n', ramlStr)
   const fpath = path.resolve(
     __dirname,
-    '../api-specs/includes/api.raml')
-  const location = `file://${fpath}`
-  const model = await wap.raml10.parse(ramlStr, location)
+    '../api-specs/includes/')
+  const baseUrl = `file://${fpath}`
+  const model = await wap.raml10.parse(ramlStr, baseUrl)
   console.log('Model location:\n', model.location)
   const resolved = await wap.raml10.resolve(model)
 

--- a/js/module/typings/webapi-parser.d.ts
+++ b/js/module/typings/webapi-parser.d.ts
@@ -146,11 +146,11 @@ declare module "webapi-parser" {
       /** Parses RAML 1.0 content from string with a custom API Doc location.
        *
        * @param content Content string to be parsed.
-       * @param location Location to assign to a doc parsed from a content string.
-       *                 References are resolved relative to this location.
+       * @param baseUrl Location to assign to a doc parsed from a content string.
+       *                References are resolved relative to this location.
        * @return Parsed WebApi Model (future).
        */
-      static parse(content: string, location: string): Promise<WebApiBaseUnit>
+      static parse(content: string, baseUrl: string): Promise<WebApiBaseUnit>
 
       /** Generates file with RAML 1.0 content.
        *
@@ -196,11 +196,11 @@ declare module "webapi-parser" {
       /** Parses RAML 0.8 content from string with a custom API Doc location.
        *
        * @param content Content string to be parsed.
-       * @param location Location to assign to a doc parsed from a content string.
-       *                 References are resolved relative to this location.
+       * @param baseUrl Location to assign to a doc parsed from a content string.
+       *                References are resolved relative to this location.
        * @return Parsed WebApi Model (future).
        */
-      static parse(content: string, location: string): Promise<WebApiBaseUnit>
+      static parse(content: string, baseUrl: string): Promise<WebApiBaseUnit>
 
       /** Generates file with RAML 0.8 content.
        *
@@ -246,11 +246,11 @@ declare module "webapi-parser" {
       /** Parses OAS 2.0 JSON content from string with a custom API Doc location.
        *
        * @param content Content string to be parsed.
-       * @param location Location to assign to a doc parsed from a content string.
-       *                 References are resolved relative to this location.
+       * @param baseUrl Location to assign to a doc parsed from a content string.
+       *                References are resolved relative to this location.
        * @return Parsed WebApi Model (future).
        */
-      static parse(content: string, location: string): Promise<WebApiBaseUnit>
+      static parse(content: string, baseUrl: string): Promise<WebApiBaseUnit>
 
       /** Generates file with OAS 2.0 JSON content.
        *
@@ -292,11 +292,11 @@ declare module "webapi-parser" {
       /** Parses OAS 2.0 YAML content from string with a custom API Doc location.
        *
        * @param content Content string to be parsed.
-       * @param location Location to assign to a doc parsed from a content string.
-       *                 References are resolved relative to this location.
+       * @param baseUrl Location to assign to a doc parsed from a content string.
+       *                References are resolved relative to this location.
        * @return Parsed WebApi Model (future).
        */
-      static parseYaml(content: string, location: string): Promise<WebApiBaseUnit>
+      static parseYaml(content: string, baseUrl: string): Promise<WebApiBaseUnit>
 
       /** Generates file with OAS 2.0 YAML content.
        *
@@ -326,11 +326,11 @@ declare module "webapi-parser" {
       /** Parses AMF Graph content from string with a custom API Doc location.
        *
        * @param content Content string to be parsed.
-       * @param location Location to assign to a doc parsed from a content string.
-       *                 References are resolved relative to this location.
+       * @param baseUrl Location to assign to a doc parsed from a content string.
+       *                References are resolved relative to this location.
        * @return Parsed WebApi Model (future).
        */
-      static parse(content: string, location: string): Promise<WebApiBaseUnit>
+      static parse(content: string, baseUrl: string): Promise<WebApiBaseUnit>
 
       /** Generates file with AMF Graph content.
        *

--- a/js/module/typings/webapi-parser.d.ts
+++ b/js/module/typings/webapi-parser.d.ts
@@ -143,6 +143,15 @@ declare module "webapi-parser" {
        */
       static parse(urlOrContent: string): Promise<WebApiBaseUnit>
 
+      /** Parses RAML 1.0 content from string with a custom API Doc location.
+       *
+       * @param content Content string to be parsed.
+       * @param location Location to assign to a doc parsed from a content string.
+       *                 References are resolved relative to this location.
+       * @return Parsed WebApi Model (future).
+       */
+      static parse(content: string, location: string): Promise<WebApiBaseUnit>
+
       /** Generates file with RAML 1.0 content.
        *
        * @param model Parsed WebApi Model to generate content from.
@@ -183,6 +192,15 @@ declare module "webapi-parser" {
        * @return Parsed WebApi Model.
        */
       static parse(urlOrContent: string): Promise<WebApiBaseUnit>
+
+      /** Parses RAML 0.8 content from string with a custom API Doc location.
+       *
+       * @param content Content string to be parsed.
+       * @param location Location to assign to a doc parsed from a content string.
+       *                 References are resolved relative to this location.
+       * @return Parsed WebApi Model (future).
+       */
+      static parse(content: string, location: string): Promise<WebApiBaseUnit>
 
       /** Generates file with RAML 0.8 content.
        *
@@ -225,6 +243,15 @@ declare module "webapi-parser" {
        */
       static parse(urlOrContent: string): Promise<WebApiBaseUnit>
 
+      /** Parses OAS 2.0 JSON content from string with a custom API Doc location.
+       *
+       * @param content Content string to be parsed.
+       * @param location Location to assign to a doc parsed from a content string.
+       *                 References are resolved relative to this location.
+       * @return Parsed WebApi Model (future).
+       */
+      static parse(content: string, location: string): Promise<WebApiBaseUnit>
+
       /** Generates file with OAS 2.0 JSON content.
        *
        * @param model Parsed WebApi Model to generate content from.
@@ -262,6 +289,15 @@ declare module "webapi-parser" {
        */
       static parseYaml(urlOrContent: string): Promise<WebApiBaseUnit>
 
+      /** Parses OAS 2.0 YAML content from string with a custom API Doc location.
+       *
+       * @param content Content string to be parsed.
+       * @param location Location to assign to a doc parsed from a content string.
+       *                 References are resolved relative to this location.
+       * @return Parsed WebApi Model (future).
+       */
+      static parseYaml(content: string, location: string): Promise<WebApiBaseUnit>
+
       /** Generates file with OAS 2.0 YAML content.
        *
        * @param model Parsed WebApi Model to generate content from.
@@ -286,6 +322,15 @@ declare module "webapi-parser" {
        * @return Parsed WebApi Model.
        */
       static parse(urlOrContent: string): Promise<WebApiBaseUnit>
+
+      /** Parses AMF Graph content from string with a custom API Doc location.
+       *
+       * @param content Content string to be parsed.
+       * @param location Location to assign to a doc parsed from a content string.
+       *                 References are resolved relative to this location.
+       * @return Parsed WebApi Model (future).
+       */
+      static parse(content: string, location: string): Promise<WebApiBaseUnit>
 
       /** Generates file with AMF Graph content.
        *

--- a/jvm/src/test/scala/webapi/AmfGraphTest.scala
+++ b/jvm/src/test/scala/webapi/AmfGraphTest.scala
@@ -22,6 +22,17 @@ class AmfGraphTest extends AsyncFunSuite with Matchers with WaitingFileReader {
       unit <- AmfGraph.parse(apiString).asInternal
     } yield {
       assertApiParsed(unit)
+      val doc = unit.asInstanceOf[WebApiDocument]
+      doc.location should be ("http://a.ml/amf/default_document")
+    }
+  }
+
+  test("String parsing with basePath") {
+    for {
+      unit <- AmfGraph.parse(apiString, "file://somewhere/something.jsonld").asInternal
+    } yield {
+      val doc = unit.asInstanceOf[WebApiDocument]
+      doc.location should be ("file://somewhere/something.jsonld")
     }
   }
 

--- a/jvm/src/test/scala/webapi/AmfGraphTest.scala
+++ b/jvm/src/test/scala/webapi/AmfGraphTest.scala
@@ -27,7 +27,7 @@ class AmfGraphTest extends AsyncFunSuite with Matchers with WaitingFileReader {
     }
   }
 
-  test("String parsing with location param") {
+  test("String parsing with baseUrl param") {
     for {
       unit <- AmfGraph.parse(apiString, "file://somewhere/something.jsonld").asInternal
     } yield {

--- a/jvm/src/test/scala/webapi/AmfGraphTest.scala
+++ b/jvm/src/test/scala/webapi/AmfGraphTest.scala
@@ -27,7 +27,7 @@ class AmfGraphTest extends AsyncFunSuite with Matchers with WaitingFileReader {
     }
   }
 
-  test("String parsing with basePath") {
+  test("String parsing with location param") {
     for {
       unit <- AmfGraph.parse(apiString, "file://somewhere/something.jsonld").asInternal
     } yield {

--- a/jvm/src/test/scala/webapi/Oas20Test.scala
+++ b/jvm/src/test/scala/webapi/Oas20Test.scala
@@ -125,7 +125,7 @@ class Oas20Test extends AsyncFunSuite with Matchers with WaitingFileReader {
       |            "$ref": "cat-schema.yaml"
       |      required: true""".stripMargin
 
-  test("JSON string parsing with reference and location param") {
+  test("JSON string parsing with reference and baseUrl param") {
     for {
       unit <- Oas20.parse(
         apiStringWithRef,
@@ -140,7 +140,7 @@ class Oas20Test extends AsyncFunSuite with Matchers with WaitingFileReader {
     }
   }
 
-  test("JSON string parsing with reference and no location param") {
+  test("JSON string parsing with reference and no baseUrl param") {
     for {
       unit <- Oas20.parse(apiStringWithRef).asInternal
       resolved <- Oas20.resolve(unit).asInternal
@@ -212,7 +212,7 @@ class Oas20Test extends AsyncFunSuite with Matchers with WaitingFileReader {
     }
   }
 
-  test("YAML string parsing with reference and location param") {
+  test("YAML string parsing with reference and baseUrl param") {
     for {
       unit <- Oas20.parseYaml(
         apiStringWithRef,
@@ -227,7 +227,7 @@ class Oas20Test extends AsyncFunSuite with Matchers with WaitingFileReader {
     }
   }
 
-  test("YAML string parsing with reference and no location param") {
+  test("YAML string parsing with reference and no baseUrl param") {
     for {
       unit <- Oas20.parseYaml(apiStringWithRef).asInternal
       resolved <- Oas20.resolve(unit).asInternal

--- a/jvm/src/test/scala/webapi/Oas20Test.scala
+++ b/jvm/src/test/scala/webapi/Oas20Test.scala
@@ -125,25 +125,29 @@ class Oas20Test extends AsyncFunSuite with Matchers with WaitingFileReader {
       |            "$ref": "cat-schema.yaml"
       |      required: true""".stripMargin
 
-  test("JSON string parsing with reference and basePath") {
+  test("JSON string parsing with reference and location param") {
     for {
       unit <- Oas20.parse(
         apiStringWithRef,
-        "file://shared/src/test/resources/includes/").asInternal
+        "file://shared/src/test/resources/includes/api.json").asInternal
       resolved <- Oas20.resolve(unit).asInternal
       genStr <- Oas20.generateString(resolved).asInternal
     } yield {
+      val doc = unit.asInstanceOf[WebApiDocument]
+      doc.location should be ("file://shared/src/test/resources/includes/api.json")
       genStr should not include ("$ref")
       genStr should include ("The cat's name")
     }
   }
 
-  test("JSON string parsing with reference and no basePath") {
+  test("JSON string parsing with reference and no location param") {
     for {
       unit <- Oas20.parse(apiStringWithRef).asInternal
       resolved <- Oas20.resolve(unit).asInternal
       genStr <- Oas20.generateString(resolved).asInternal
     } yield {
+      val doc = unit.asInstanceOf[WebApiDocument]
+      doc.location should be ("http://a.ml/amf/default_document")
       genStr should not include ("$ref")
       genStr should not include ("The cat's name")
     }
@@ -208,25 +212,29 @@ class Oas20Test extends AsyncFunSuite with Matchers with WaitingFileReader {
     }
   }
 
-  test("YAML string parsing with reference and basePath") {
+  test("YAML string parsing with reference and location param") {
     for {
       unit <- Oas20.parseYaml(
         apiStringWithRef,
-        "file://shared/src/test/resources/includes/").asInternal
+        "file://shared/src/test/resources/includes/api.yaml").asInternal
       resolved <- Oas20.resolve(unit).asInternal
       genStr <- Oas20.generateYamlString(resolved).asInternal
     } yield {
+      val doc = unit.asInstanceOf[WebApiDocument]
+      doc.location should be ("file://shared/src/test/resources/includes/api.yaml")
       genStr should not include ("$ref")
       genStr should include ("The cat's name")
     }
   }
 
-  test("YAML string parsing with reference and no basePath") {
+  test("YAML string parsing with reference and no location param") {
     for {
       unit <- Oas20.parseYaml(apiStringWithRef).asInternal
       resolved <- Oas20.resolve(unit).asInternal
       genStr <- Oas20.generateYamlString(resolved).asInternal
     } yield {
+      val doc = unit.asInstanceOf[WebApiDocument]
+      doc.location should be ("http://a.ml/amf/default_document")
       genStr should not include ("$ref")
       genStr should not include ("The cat's name")
     }

--- a/jvm/src/test/scala/webapi/Raml08Test.scala
+++ b/jvm/src/test/scala/webapi/Raml08Test.scala
@@ -36,7 +36,7 @@ class Raml08Test extends AsyncFunSuite with Matchers with WaitingFileReader {
       |          application/json:
       |            schema: !include cat-schema.json""".stripMargin
 
-  test("String parsing with reference and location param") {
+  test("String parsing with reference and baseUrl param") {
     for {
       unit <- Raml08.parse(
         apiStringWithRef,
@@ -51,7 +51,7 @@ class Raml08Test extends AsyncFunSuite with Matchers with WaitingFileReader {
     }
   }
 
-  test("String parsing with reference and no location param") {
+  test("String parsing with reference and no baseUrl param") {
     for {
       unit <- Raml08.parse(apiStringWithRef).asInternal
       resolved <- Raml08.resolve(unit).asInternal

--- a/jvm/src/test/scala/webapi/Raml08Test.scala
+++ b/jvm/src/test/scala/webapi/Raml08Test.scala
@@ -36,25 +36,29 @@ class Raml08Test extends AsyncFunSuite with Matchers with WaitingFileReader {
       |          application/json:
       |            schema: !include cat-schema.json""".stripMargin
 
-  test("String parsing with reference and basePath") {
+  test("String parsing with reference and location param") {
     for {
       unit <- Raml08.parse(
         apiStringWithRef,
-        "file://shared/src/test/resources/includes/").asInternal
+        "file://shared/src/test/resources/includes/api.raml").asInternal
       resolved <- Raml08.resolve(unit).asInternal
       genStr <- Raml08.generateString(resolved).asInternal
     } yield {
+      val doc = unit.asInstanceOf[WebApiDocument]
+      doc.location should be ("file://shared/src/test/resources/includes/api.raml")
       genStr should not include ("!include")
       genStr should include ("The cat's name")
     }
   }
 
-  test("String parsing with reference and no basePath") {
+  test("String parsing with reference and no location param") {
     for {
       unit <- Raml08.parse(apiStringWithRef).asInternal
       resolved <- Raml08.resolve(unit).asInternal
       genStr <- Raml08.generateString(resolved).asInternal
     } yield {
+      val doc = unit.asInstanceOf[WebApiDocument]
+      doc.location should be ("http://a.ml/amf/default_document")
       genStr should not include ("!include")
       genStr should not include ("The cat's name")
     }

--- a/jvm/src/test/scala/webapi/Raml10Test.scala
+++ b/jvm/src/test/scala/webapi/Raml10Test.scala
@@ -45,7 +45,7 @@ class Raml10Test extends AsyncFunSuite with Matchers with WaitingFileReader {
       |          application/json:
       |            type: !include cat-schema.json""".stripMargin
 
-  test("String parsing with reference and location param") {
+  test("String parsing with reference and baseUrl param") {
     for {
       unit <- Raml10.parse(
         apiStringWithRef,
@@ -60,7 +60,7 @@ class Raml10Test extends AsyncFunSuite with Matchers with WaitingFileReader {
     }
   }
 
-  test("String parsing with reference and no location param") {
+  test("String parsing with reference and no baseUrl param") {
     for {
       unit <- Raml10.parse(apiStringWithRef).asInternal
       resolved <- Raml10.resolve(unit).asInternal

--- a/jvm/src/test/scala/webapi/Raml10Test.scala
+++ b/jvm/src/test/scala/webapi/Raml10Test.scala
@@ -45,25 +45,29 @@ class Raml10Test extends AsyncFunSuite with Matchers with WaitingFileReader {
       |          application/json:
       |            type: !include cat-schema.json""".stripMargin
 
-  test("String parsing with reference and basePath") {
+  test("String parsing with reference and location param") {
     for {
       unit <- Raml10.parse(
         apiStringWithRef,
-        "file://shared/src/test/resources/includes/").asInternal
+        "file://shared/src/test/resources/includes/api.raml").asInternal
       resolved <- Raml10.resolve(unit).asInternal
       genStr <- Raml10.generateString(resolved).asInternal
     } yield {
+      val doc = unit.asInstanceOf[WebApiDocument]
+      doc.location should be ("file://shared/src/test/resources/includes/api.raml")
       genStr should not include ("!include")
       genStr should include ("The cat's name")
     }
   }
 
-  test("String parsing with reference and no basePath") {
+  test("String parsing with reference and no location param") {
     for {
       unit <- Raml10.parse(apiStringWithRef).asInternal
       resolved <- Raml10.resolve(unit).asInternal
       genStr <- Raml10.generateString(resolved).asInternal
     } yield {
+      val doc = unit.asInstanceOf[WebApiDocument]
+      doc.location should be ("http://a.ml/amf/default_document")
       genStr should not include ("!include")
       genStr should include ("type: any")
     }

--- a/shared/src/main/scala/webapi/WebApiParser.scala
+++ b/shared/src/main/scala/webapi/WebApiParser.scala
@@ -81,13 +81,13 @@ object Raml10 {
   /** Parses RAML 1.0 content from string with a custom API Doc location.
     *
     * @param content Content string to be parsed.
-    * @param location Location to assign to a doc parsed from a content string.
-    *                 References are resolved relative to this location.
+    * @param baseUrl Location to assign to a doc parsed from a content string.
+    *                References are resolved relative to this location.
     * @return Parsed WebApi Model (future).
     */
-  def parse(content: String, location: String): ClientFuture[WebApiBaseUnit] = {
+  def parse(content: String, baseUrl: String): ClientFuture[WebApiBaseUnit] = {
     WebApiParser.chainAfterInit(() => {
-      new Raml10Parser().parseStringAsync(location, content).asInternal
+      new Raml10Parser().parseStringAsync(baseUrl, content).asInternal
     }).asClient
   }
 
@@ -164,13 +164,13 @@ object Raml08 {
   /** Parses RAML 0.8 content from string with a custom API Doc location.
     *
     * @param content Content string to be parsed.
-    * @param location Location to assign to a doc parsed from a content string.
-    *                 References are resolved relative to this location.
+    * @param baseUrl Location to assign to a doc parsed from a content string.
+    *                References are resolved relative to this location.
     * @return Parsed WebApi Model (future).
     */
-  def parse(content: String, location: String): ClientFuture[WebApiBaseUnit] = {
+  def parse(content: String, baseUrl: String): ClientFuture[WebApiBaseUnit] = {
     WebApiParser.chainAfterInit(() => {
-      new Raml08Parser().parseStringAsync(location, content).asInternal
+      new Raml08Parser().parseStringAsync(baseUrl, content).asInternal
     }).asClient
   }
 
@@ -247,13 +247,13 @@ object Oas20 {
   /** Parses OAS 2.0 JSON content from string with a custom API Doc location.
     *
     * @param content Content string to be parsed.
-    * @param location Location to assign to a doc parsed from a content string.
-    *                 References are resolved relative to this location.
+    * @param baseUrl Location to assign to a doc parsed from a content string.
+    *                References are resolved relative to this location.
     * @return Parsed WebApi Model (future).
     */
-  def parse(content: String, location: String): ClientFuture[WebApiBaseUnit] = {
+  def parse(content: String, baseUrl: String): ClientFuture[WebApiBaseUnit] = {
     WebApiParser.chainAfterInit(() => {
-      new Oas20Parser().parseStringAsync(location, content).asInternal
+      new Oas20Parser().parseStringAsync(baseUrl, content).asInternal
     }).asClient
   }
 
@@ -324,13 +324,13 @@ object Oas20 {
   /** Parses OAS 2.0 YAML content from string with a custom API Doc location.
     *
     * @param content Content string to be parsed.
-    * @param location Location to assign to a doc parsed from a content string.
-    *                 References are resolved relative to this location.
+    * @param baseUrl Location to assign to a doc parsed from a content string.
+    *                References are resolved relative to this location.
     * @return Parsed WebApi Model (future).
     */
-  def parseYaml(content: String, location: String): ClientFuture[WebApiBaseUnit] = {
+  def parseYaml(content: String, baseUrl: String): ClientFuture[WebApiBaseUnit] = {
     WebApiParser.chainAfterInit(() => {
-      new Oas20YamlParser().parseStringAsync(location, content).asInternal
+      new Oas20YamlParser().parseStringAsync(baseUrl, content).asInternal
     }).asClient
   }
 
@@ -380,13 +380,13 @@ object AmfGraph {
   /** Parses AMF Graph content from string with a custom API Doc location.
     *
     * @param content Content string to be parsed.
-    * @param location Location to assign to a doc parsed from a content string.
-    *                 References are resolved relative to this location.
+    * @param baseUrl Location to assign to a doc parsed from a content string.
+    *                References are resolved relative to this location.
     * @return Parsed WebApi Model (future).
     */
-  def parse(content: String, location: String): ClientFuture[WebApiBaseUnit] = {
+  def parse(content: String, baseUrl: String): ClientFuture[WebApiBaseUnit] = {
     WebApiParser.chainAfterInit(() => {
-      new AmfGraphParser().parseStringAsync(location, content).asInternal
+      new AmfGraphParser().parseStringAsync(baseUrl, content).asInternal
     }).asClient
   }
 

--- a/shared/src/main/scala/webapi/WebApiParser.scala
+++ b/shared/src/main/scala/webapi/WebApiParser.scala
@@ -78,16 +78,16 @@ object Raml10 {
     }).asClient
   }
 
-  /** Parses RAML 1.0 content from string with specific API doc base path.
-    * References from API doc are resolved relative to specified base path.
+  /** Parses RAML 1.0 content from string with a custom API Doc location.
     *
     * @param content Content string to be parsed.
-    * @param basePath API doc location to use when parsing content string.
+    * @param location Location to assign to a doc parsed from a content string.
+    *                 References are resolved relative to this location.
     * @return Parsed WebApi Model (future).
     */
-  def parse(content: String, basePath: String): ClientFuture[WebApiBaseUnit] = {
+  def parse(content: String, location: String): ClientFuture[WebApiBaseUnit] = {
     WebApiParser.chainAfterInit(() => {
-      new Raml10Parser().parseStringAsync(basePath, content).asInternal
+      new Raml10Parser().parseStringAsync(location, content).asInternal
     }).asClient
   }
 
@@ -161,16 +161,16 @@ object Raml08 {
     }).asClient
   }
 
-  /** Parses RAML 0.8 content from string with specific API doc base path.
-    * References from API doc are resolved relative to specified base path.
+  /** Parses RAML 0.8 content from string with a custom API Doc location.
     *
     * @param content Content string to be parsed.
-    * @param basePath API doc location to use when parsing content string.
+    * @param location Location to assign to a doc parsed from a content string.
+    *                 References are resolved relative to this location.
     * @return Parsed WebApi Model (future).
     */
-  def parse(content: String, basePath: String): ClientFuture[WebApiBaseUnit] = {
+  def parse(content: String, location: String): ClientFuture[WebApiBaseUnit] = {
     WebApiParser.chainAfterInit(() => {
-      new Raml08Parser().parseStringAsync(basePath, content).asInternal
+      new Raml08Parser().parseStringAsync(location, content).asInternal
     }).asClient
   }
 
@@ -244,16 +244,16 @@ object Oas20 {
     }).asClient
   }
 
-  /** Parses OAS 2.0 JSON content from string with specific API doc base path.
-    * References from API doc are resolved relative to specified base path.
+  /** Parses OAS 2.0 JSON content from string with a custom API Doc location.
     *
     * @param content Content string to be parsed.
-    * @param basePath API doc location to use when parsing content string.
+    * @param location Location to assign to a doc parsed from a content string.
+    *                 References are resolved relative to this location.
     * @return Parsed WebApi Model (future).
     */
-  def parse(content: String, basePath: String): ClientFuture[WebApiBaseUnit] = {
+  def parse(content: String, location: String): ClientFuture[WebApiBaseUnit] = {
     WebApiParser.chainAfterInit(() => {
-      new Oas20Parser().parseStringAsync(basePath, content).asInternal
+      new Oas20Parser().parseStringAsync(location, content).asInternal
     }).asClient
   }
 
@@ -321,16 +321,16 @@ object Oas20 {
     }).asClient
   }
 
-  /** Parses OAS 2.0 YAML content from string with specific API doc base path.
-    * References from API doc are resolved relative to specified base path.
+  /** Parses OAS 2.0 YAML content from string with a custom API Doc location.
     *
     * @param content Content string to be parsed.
-    * @param basePath API doc location to use when parsing content string.
+    * @param location Location to assign to a doc parsed from a content string.
+    *                 References are resolved relative to this location.
     * @return Parsed WebApi Model (future).
     */
-  def parseYaml(content: String, basePath: String): ClientFuture[WebApiBaseUnit] = {
+  def parseYaml(content: String, location: String): ClientFuture[WebApiBaseUnit] = {
     WebApiParser.chainAfterInit(() => {
-      new Oas20YamlParser().parseStringAsync(basePath, content).asInternal
+      new Oas20YamlParser().parseStringAsync(location, content).asInternal
     }).asClient
   }
 
@@ -377,15 +377,16 @@ object AmfGraph {
     }).asClient
   }
 
-  /** Parses AMF Graph content from string with specific API doc base path.
+  /** Parses AMF Graph content from string with a custom API Doc location.
     *
     * @param content Content string to be parsed.
-    * @param basePath API doc location to use when parsing content string.
+    * @param location Location to assign to a doc parsed from a content string.
+    *                 References are resolved relative to this location.
     * @return Parsed WebApi Model (future).
     */
-  def parse(content: String, basePath: String): ClientFuture[WebApiBaseUnit] = {
+  def parse(content: String, location: String): ClientFuture[WebApiBaseUnit] = {
     WebApiParser.chainAfterInit(() => {
-      new AmfGraphParser().parseStringAsync(basePath, content).asInternal
+      new AmfGraphParser().parseStringAsync(location, content).asInternal
     }).asClient
   }
 

--- a/shared/src/main/scala/webapi/WebApiParser.scala
+++ b/shared/src/main/scala/webapi/WebApiParser.scala
@@ -78,6 +78,19 @@ object Raml10 {
     }).asClient
   }
 
+  /** Parses RAML 1.0 content from string with specific API doc base path.
+    * References from API doc are resolved relative to specified base path.
+    *
+    * @param content Content string to be parsed.
+    * @param basePath API doc location to use when parsing content string.
+    * @return Parsed WebApi Model (future).
+    */
+  def parse(content: String, basePath: String): ClientFuture[WebApiBaseUnit] = {
+    WebApiParser.chainAfterInit(() => {
+      new Raml10Parser().parseStringAsync(basePath, content).asInternal
+    }).asClient
+  }
+
   /** Generates file with RAML 1.0 content.
     *
     * @param model Parsed WebApi Model to generate content from.
@@ -145,6 +158,19 @@ object Raml08 {
       } else {
         new Raml08Parser().parseStringAsync(urlOrContent).asInternal
       }
+    }).asClient
+  }
+
+  /** Parses RAML 0.8 content from string with specific API doc base path.
+    * References from API doc are resolved relative to specified base path.
+    *
+    * @param content Content string to be parsed.
+    * @param basePath API doc location to use when parsing content string.
+    * @return Parsed WebApi Model (future).
+    */
+  def parse(content: String, basePath: String): ClientFuture[WebApiBaseUnit] = {
+    WebApiParser.chainAfterInit(() => {
+      new Raml08Parser().parseStringAsync(basePath, content).asInternal
     }).asClient
   }
 
@@ -218,6 +244,19 @@ object Oas20 {
     }).asClient
   }
 
+  /** Parses OAS 2.0 JSON content from string with specific API doc base path.
+    * References from API doc are resolved relative to specified base path.
+    *
+    * @param content Content string to be parsed.
+    * @param basePath API doc location to use when parsing content string.
+    * @return Parsed WebApi Model (future).
+    */
+  def parse(content: String, basePath: String): ClientFuture[WebApiBaseUnit] = {
+    WebApiParser.chainAfterInit(() => {
+      new Oas20Parser().parseStringAsync(basePath, content).asInternal
+    }).asClient
+  }
+
   /** Generates file with OAS 2.0 JSON content.
     *
     * @param model Parsed WebApi Model to generate content from.
@@ -279,6 +318,19 @@ object Oas20 {
       } else {
         new Oas20YamlParser().parseStringAsync(urlOrContent).asInternal
       }
+    }).asClient
+  }
+
+  /** Parses OAS 2.0 YAML content from string with specific API doc base path.
+    * References from API doc are resolved relative to specified base path.
+    *
+    * @param content Content string to be parsed.
+    * @param basePath API doc location to use when parsing content string.
+    * @return Parsed WebApi Model (future).
+    */
+  def parseYaml(content: String, basePath: String): ClientFuture[WebApiBaseUnit] = {
+    WebApiParser.chainAfterInit(() => {
+      new Oas20YamlParser().parseStringAsync(basePath, content).asInternal
     }).asClient
   }
 

--- a/shared/src/main/scala/webapi/WebApiParser.scala
+++ b/shared/src/main/scala/webapi/WebApiParser.scala
@@ -377,6 +377,18 @@ object AmfGraph {
     }).asClient
   }
 
+  /** Parses AMF Graph content from string with specific API doc base path.
+    *
+    * @param content Content string to be parsed.
+    * @param basePath API doc location to use when parsing content string.
+    * @return Parsed WebApi Model (future).
+    */
+  def parse(content: String, basePath: String): ClientFuture[WebApiBaseUnit] = {
+    WebApiParser.chainAfterInit(() => {
+      new AmfGraphParser().parseStringAsync(basePath, content).asInternal
+    }).asClient
+  }
+
   /** Generates file with AMF Graph content.
     *
     * @param model Parsed WebApi Model to generate content from.

--- a/shared/src/test/resources/includes/cat-schema.json
+++ b/shared/src/test/resources/includes/cat-schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://example.com/cat.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Cat",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The cat's name."
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/shared/src/test/resources/includes/cat-schema.yaml
+++ b/shared/src/test/resources/includes/cat-schema.yaml
@@ -1,0 +1,12 @@
+"$id": https://example.com/cat.schema.json
+"$schema": http://json-schema.org/draft-04/schema#
+title: Cat
+type: object
+properties:
+  name:
+    type: string
+    description: The cat's name.
+  age:
+    description: Age in years which must be equal to or greater than zero.
+    type: integer
+    minimum: 0


### PR DESCRIPTION
Fixes #35

---

#### New Things
All syntaxes' `parse()` methods [1] now accept second argument when parsing a content string:
* `location` - Location to assign to a document parsed from a content string. Also references are resolved relative to this location.

See [JS](https://github.com/raml-org/webapi-parser/blob/8171fb04145859427f8d4fbb1d417f72704a6c85/examples/js/raml10-string-location.js) and [Java](https://github.com/raml-org/webapi-parser/blob/8171fb04145859427f8d4fbb1d417f72704a6c85/examples/java/src/main/java/co/acme/parse/Raml10Parsing.java#L47) RAML 1.0 examples for usage details.

[1] `raml10.parse(), raml08.parse(), oas20.parse(), oas20.parseYaml(), amfGraph.parse()`.