### PR TITLE
Fixes #44: Copy README to npm package before publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ classes
 # Ignore generated JS and .jar
 /js/module/webapi-parser.js
 /js/module/package-lock.json
+/js/module/README.md
 /examples/js/package-lock.json
 /examples/java/libs/*.jar
 webapi-parser-*.jar

--- a/scripts/publish-js.sh
+++ b/scripts/publish-js.sh
@@ -37,6 +37,7 @@ echo "Running buildjs script"
 ./scripts/buildjs.sh
 echo "Finished buildjs script"
 
+cp README.md js/module
 cd js/module
 
 # Create per-project NPM config file with credentials


### PR DESCRIPTION
Fixes #44: Copy README to npm package before publishing.

README to npm will be added on the next release.